### PR TITLE
Add basic component. Already working with npm link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,407 @@
+{
+  "name": "react-themed-gist",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+    },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+    },
+    "core-js": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+      "optional": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "create-react-class": {
+      "version": "15.6.3",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
+      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
+      "requires": {
+        "fbjs": "0.8.17",
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        },
+        "fbjs": {
+          "version": "0.8.17",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+          "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.4.0",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.18"
+          }
+        }
+      }
+    },
+    "css": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+      "requires": {
+        "inherits": "2.0.3",
+        "source-map": "0.6.1",
+        "source-map-resolve": "0.5.2",
+        "urix": "0.1.0"
+      }
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+    },
+    "domhandler": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
+    },
+    "domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+    },
+    "fbjs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+      "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+      "optional": true,
+      "requires": {
+        "core-js": "2.5.7",
+        "fbjs-css-vars": "1.0.1",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.18"
+      }
+    },
+    "fbjs-css-vars": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.1.tgz",
+      "integrity": "sha512-IM+v/C40MNZWqsLErc32e0TyIk/NhkkQZL0QmjBh6zi1eXv0/GeVKmKmueQX7nn9SXQBQbTUcB8zuexIF3/88w==",
+      "optional": true
+    },
+    "fetch-jsonp": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fetch-jsonp/-/fetch-jsonp-1.1.3.tgz",
+      "integrity": "sha1-nrnlhboIqvcAVjU40Xu+u81aPbI="
+    },
+    "html-dom-parser": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-0.1.3.tgz",
+      "integrity": "sha512-kGhjJDkfiA2/3y0gc2Bi+rseJWJSKz4CioS4EM+vN80fw863f1hn3G+7EaP0/benxceky4a8TzEeW6+dDjUh7A==",
+      "requires": {
+        "domhandler": "2.3.0",
+        "htmlparser2": "3.9.1"
+      }
+    },
+    "html-react-parser": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-0.4.7.tgz",
+      "integrity": "sha512-h3EUYXqKXts68/ynQwH5ws57vg2P94VzvzpwVRwYgWjW+uEtkXDjOO8q/7UmfcGX4DFHJ69UlQJa1RoRXCTaPg==",
+      "requires": {
+        "html-dom-parser": "0.1.3",
+        "react-dom-core": "0.0.3",
+        "style-to-object": "0.2.2"
+      }
+    },
+    "htmlparser2": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.1.tgz",
+      "integrity": "sha1-Yht6WLyazQA/evCiyaAKpnyFBdI=",
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.3.0",
+        "domutils": "1.7.0",
+        "entities": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "3.0.0"
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "4.0.0"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
+    "prop-types": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "requires": {
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "react": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
+      "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+      "requires": {
+        "create-react-class": "15.6.3",
+        "fbjs": "0.8.17",
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        },
+        "fbjs": {
+          "version": "0.8.17",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+          "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.4.0",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.18"
+          }
+        }
+      }
+    },
+    "react-dom-core": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/react-dom-core/-/react-dom-core-0.0.3.tgz",
+      "integrity": "sha512-pMMNOU4Hhe/LmkGWMVOpQmPnKQo+bGaWY3Y0+OjXmsQVB5LJ3sr4hVCM/7MpcRGeEMcfaRaoHyiLhufzk/BL4w==",
+      "requires": {
+        "fbjs": "1.0.0",
+        "object-assign": "4.1.1",
+        "react": "15.6.2"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "requires": {
+        "atob": "2.1.2",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "style-to-object": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.2.2.tgz",
+      "integrity": "sha512-GcbtvfsqyKmIPpHeOHZ5Rmwsx2MDJct4W9apmTGcbPTbpA2FcgTFl2Z43Hm4Qb61MWGPNK8Chki7ITiY7lLOow==",
+      "requires": {
+        "css": "2.2.4"
+      }
+    },
+    "ua-parser-js": {
+      "version": "0.7.18",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+      "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "react-themed-gist",
+  "version": "0.0.1",
+  "description": "React component to embed a gist with theme options",
+  "main": "src/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "classnames": "^2.2.6",
+    "fetch-jsonp": "^1.1.3",
+    "html-react-parser": "^0.4.7"
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,77 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Parser from 'html-react-parser';
+import fetchJsonp from 'fetch-jsonp';
+import classnames from 'classnames';
+
+import './style.css';
+
+const getGistUrl = (id, file) =>
+  `https://gist.github.com/${id}.json${file ? `?file=${file}` : ''}`
+
+class Gist extends Component {
+  state = { loading: true, src: "" };
+  
+  componentDidMount() {
+    const { id, file } = this.props;
+		const url = getGistUrl(id, file);
+		
+		fetchJsonp(url)
+			.then((response) => response.json())
+			.then((data) => {
+				this.setState({
+					loading: false,
+					src: data.div
+				})
+				Gist.addStylesheet(data.stylesheet)
+			});
+  }
+
+  render() {
+    const { loading, src } = this.state;
+    const { hideMeta, theme, loader: Loader } = this.props;
+
+    if (loading) {
+      return Loader;
+    }
+
+    return <div className={classnames(
+        'themed-gist',
+        { 'hide-meta': hideMeta },
+        theme
+    )}>
+      {Parser(src)}
+    </div>;
+  }
+}
+
+Gist.addedStylesheets = [];
+
+Gist.addStylesheet = (href) => {
+  if (!Gist.addedStylesheets.includes(href)) {
+    Gist.addedStylesheets.push(href);
+
+    const link = document.createElement('link');
+    link.type = "text/css";
+    link.rel = "stylesheet";
+    link.href = href;
+
+    document.head.appendChild(link);
+  }
+}
+
+Gist.defaultProps = {
+  hideMeta: false,
+  theme: '',
+  loader: null,
+}
+
+Gist.propTypes = {
+    loader: PropTypes.any,
+    id: PropTypes.string.isRequired, // e.g. "username/id"
+    file: PropTypes.string, // to embed a single specific file from the gist
+    hideMeta: PropTypes.bool,
+    theme: PropTypes.string,
+};
+
+export default Gist;

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,22 @@
+/* https://github.com/lonekorean/gist-syntax-themes */
+@import './themes/chaos.css';
+@import './themes/cobalt.css';
+@import './themes/idle-fingers.css';
+@import './themes/monokai.css';
+@import './themes/obsidian.css';
+@import './themes/one-dark.css';
+@import './themes/pastel-on-dark.css';
+@import './themes/solarized-dark.css';
+@import './themes/solarized-light.css';
+@import './themes/terminal.css';
+@import './themes/tomorrow-night.css';
+@import './themes/twilight.css';
+
+.themed-gist {
+  margin: 20px;
+  font: 16px 'Open Sans', sans-serif;
+}
+
+.hide-meta .gist-meta {
+  display: none;
+}

--- a/src/themes/chaos.css
+++ b/src/themes/chaos.css
@@ -1,0 +1,90 @@
+.chaos .gist .highlight {
+    background: #161616;
+}
+.chaos .gist .blob-num,
+.chaos .gist .blob-code-inner,
+.chaos .gist .pl-st {
+    color: #e6e1dc;
+}
+.chaos .gist .pl-c,
+.chaos .gist .pl-c span {
+    color: #555;
+    font-style: italic;
+}
+.chaos .gist .pl-mb {
+    color: #1edafb;
+    font-weight: 700;
+}
+.chaos .gist .pl-mh .pl-en {
+    color: #fdc251;
+    font-weight: 700;
+}
+.chaos .gist .pl-mi {
+    color: #00698f;
+    font-style: italic;
+}
+.chaos .gist .pl-mq {
+    color: #555;
+}
+.chaos .gist .pl-sc {
+    color: #999;
+}
+.chaos .gist .pl-c1,
+.chaos .gist .pl-mh,
+.chaos .gist .pl-sr .pl-cce {
+    color: #fdc251;
+}
+.chaos .gist .pl-e,
+.chaos .gist .pl-en,
+.chaos .gist .pl-ent,
+.chaos .gist .pl-s,
+.chaos .gist .pl-v,
+.chaos .gist .pl-vpf {
+    color: #974;
+}
+.chaos .gist .pl-k,
+.chaos .gist .pl-mdh,
+.chaos .gist .pl-mdr,
+.chaos .gist .pl-ml,
+.chaos .gist .pl-mm,
+.chaos .gist .pl-mo,
+.chaos .gist .pl-mp,
+.chaos .gist .pl-mr,
+.chaos .gist .pl-ms,
+.chaos .gist .pl-s1 .pl-v,
+.chaos .gist .pl-s3 {
+    color: #00698f;
+}
+.chaos .gist .pl-pds,
+.chaos .gist .pl-s1,
+.chaos .gist .pl-s1 .pl-pse .pl-s2 {
+    color: #58c554;
+}
+.chaos .gist .pl-s1 .pl-s2,
+.chaos .gist .pl-sv {
+    color: #1edafb;
+}
+.chaos .gist .pl-smi,
+.chaos .gist .pl-smp,
+.chaos .gist .pl-stj,
+.chaos .gist .pl-vo {
+    color: #be53e6;
+}
+.chaos .gist .pl-sr,
+.chaos .gist .pl-sr .pl-sra,
+.chaos .gist .pl-sr .pl-sre,
+.chaos .gist .pl-src {
+    color: #ff308f;
+}
+.chaos .gist .pl-mi1,
+.chaos .gist .pl-mdht {
+    color: #fff;
+    background: rgba(0, 64, 0, .5);
+}
+.chaos .gist .pl-md,
+.chaos .gist .pl-mdhf,
+.chaos .gist .pl-id,
+.chaos .gist .pl-ii {
+    color: #fff;
+    background: #900;
+}

--- a/src/themes/cobalt.css
+++ b/src/themes/cobalt.css
@@ -1,0 +1,96 @@
+.cobalt .gist .highlight {
+    background: #002240;
+}
+.cobalt .gist .blob-num,
+.cobalt .gist .blob-code-inner,
+.cobalt .gist .pl-en {
+    color: #fff;
+}
+.cobalt .gist .pl-mb,
+.cobalt .gist .pl-mh .pl-en {
+     font-weight: 700;
+}
+.cobalt .gist .pl-c,
+.cobalt .gist .pl-c span,
+.cobalt .gist .pl-mi {
+     font-style: italic;
+}
+.cobalt .gist .pl-ent,
+.cobalt .gist .pl-v {
+     color: #fd0;
+}
+.cobalt .gist .pl-mh,
+.cobalt .gist .pl-mh .pl-en,
+.cobalt .gist .pl-sr .pl-cce {
+     color: #eb939a;
+}
+.cobalt .gist .pl-pds,
+.cobalt .gist .pl-s,
+.cobalt .gist .pl-s1,
+.cobalt .gist .pl-s1 .pl-pse .pl-s2,
+.cobalt .gist .pl-s1 .pl-v {
+     color: #3ad900;
+}
+.cobalt .gist .pl-s1 .pl-s2,
+.cobalt .gist .pl-smi,
+.cobalt .gist .pl-smp,
+.cobalt .gist .pl-stj,
+.cobalt .gist .pl-vo,
+.cobalt .gist .pl-vpf {
+     color: #ccc;
+}
+.cobalt .gist .pl-s3,
+.cobalt .gist .pl-sc {
+     color: #ffb054;
+}
+.cobalt .gist .pl-sr,
+.cobalt .gist .pl-sr .pl-sra,
+.cobalt .gist .pl-sr .pl-sre,
+.cobalt .gist .pl-src {
+     color: #80ffc2;
+}
+.cobalt .gist .pl-mdht,
+.cobalt .gist .pl-mi1 {
+     color: #f8f8f8;
+     background: rgba(0, 64, 0, .5);
+}
+.cobalt .gist .pl-id,
+.cobalt .gist .pl-ii,
+.cobalt .gist .pl-md,
+.cobalt .gist .pl-mdhf {
+     color: #f8f8f8;
+     background: #800f00;
+}
+.cobalt .gist .highlight-source-js .pl-st {
+     color: #ffee80;
+}
+.cobalt .gist .highlight-source-css .pl-s3 {
+     color: #80ffbb;
+}
+.cobalt .gist .highlight-text-html-basic .pl-ent {
+     color: #9effff;
+}
+.cobalt .gist .pl-c,
+.cobalt .gist .pl-c span,
+.cobalt .gist .pl-mq {
+     color: #08f;
+}
+.cobalt .gist .pl-c1,
+.cobalt .gist .pl-sv,
+.cobalt .gist .pl-mb {
+     color: #ff628c;
+}
+.cobalt .gist .pl-e,
+.cobalt .gist .pl-k,
+.cobalt .gist .pl-mdh,
+.cobalt .gist .pl-mdr,
+.cobalt .gist .pl-ml,
+.cobalt .gist .pl-mm,
+.cobalt .gist .pl-mo,
+.cobalt .gist .pl-mp,
+.cobalt .gist .pl-mr,
+.cobalt .gist .pl-ms,
+.cobalt .gist .pl-st,
+.cobalt .gist .pl-mi {
+     color: #ff9d00;
+}

--- a/src/themes/idle-fingers.css
+++ b/src/themes/idle-fingers.css
@@ -1,0 +1,143 @@
+.idle-fingers .gist .highlight {
+    background: #323232;
+}
+.idle-fingers .gist .blob-num,
+.idle-fingers .gist .blob-code-inner,
+.idle-fingers .gist .pl-s2,
+.idle-fingers .gist .pl-stj,
+.idle-fingers .gist .pl-vo,
+.idle-fingers .gist .pl-id,
+.idle-fingers .gist .pl-ii {
+     color: #fff;
+}
+.idle-fingers .gist .pl-enti,
+.idle-fingers .gist .pl-mb,
+.idle-fingers .gist .pl-pdb {
+     font-weight: 700;
+}
+.idle-fingers .gist .pl-c,
+.idle-fingers .gist .pl-c span,
+.idle-fingers .gist .pl-pdc {
+     color: #bc9458;
+     font-style: italic;
+}
+.idle-fingers .gist .pl-c1,
+.idle-fingers .gist .pl-pdc1,
+.idle-fingers .gist .pl-scp {
+     color: #6c99bb;
+}
+.idle-fingers .gist .pl-ent,
+.idle-fingers .gist .pl-eoa,
+.idle-fingers .gist .pl-eoai,
+.idle-fingers .gist .pl-eoai .pl-pde,
+.idle-fingers .gist .pl-ko,
+.idle-fingers .gist .pl-kolp,
+.idle-fingers .gist .pl-mc,
+.idle-fingers .gist .pl-mr,
+.idle-fingers .gist .pl-ms,
+.idle-fingers .gist .pl-s3,
+.idle-fingers .gist .pl-sok {
+     color: #ffe5bb;
+}
+.idle-fingers .gist .pl-mdh,
+.idle-fingers .gist .pl-mdi,
+.idle-fingers .gist .pl-mdr {
+     font-weight: 400;
+}
+.idle-fingers .gist .pl-mi,
+.idle-fingers .gist .pl-pdi {
+     color: #ffe5bb;
+     font-style: italic;
+}
+.idle-fingers .gist .pl-sra,
+.idle-fingers .gist .pl-src,
+.idle-fingers .gist .pl-sre {
+     color: #cc3;
+}
+.idle-fingers .gist .pl-mdht,
+.idle-fingers .gist .pl-mi1 {
+     color: #a5c261;
+     background: rgba(0, 64, 0, .5);
+}
+.idle-fingers .gist .pl-md,
+.idle-fingers .gist .pl-mdhf {
+     color: #b83426;
+     background: rgba(64, 0, 0, .5);
+}
+.idle-fingers .gist .pl-ib,
+.idle-fingers .gist .pl-id,
+.idle-fingers .gist .pl-ii,
+.idle-fingers .gist .pl-iu {
+     background: #b83426;
+}
+.idle-fingers .gist .pl-ms1 {
+     background: #ffc66d;
+}
+.idle-fingers .gist .highlight-text-html-basic .pl-ent,
+.idle-fingers .gist .pl-cce,
+.idle-fingers .gist .pl-cn,
+.idle-fingers .gist .pl-coc,
+.idle-fingers .gist .pl-enc,
+.idle-fingers .gist .pl-ens,
+.idle-fingers .gist .pl-k,
+.idle-fingers .gist .pl-kos,
+.idle-fingers .gist .pl-kou,
+.idle-fingers .gist .pl-mh .pl-pdh,
+.idle-fingers .gist .pl-mp,
+.idle-fingers .gist .pl-mp .pl-s3,
+.idle-fingers .gist .pl-mp1 .pl-sf,
+.idle-fingers .gist .pl-mq,
+.idle-fingers .gist .pl-mri,
+.idle-fingers .gist .pl-pde,
+.idle-fingers .gist .pl-pse,
+.idle-fingers .gist .pl-pse .pl-s2,
+.idle-fingers .gist .pl-s,
+.idle-fingers .gist .pl-st,
+.idle-fingers .gist .pl-stp,
+.idle-fingers .gist .pl-sv,
+.idle-fingers .gist .pl-v,
+.idle-fingers .gist .pl-va,
+.idle-fingers .gist .pl-vi,
+.idle-fingers .gist .pl-vpf,
+.idle-fingers .gist .pl-vpu,
+.idle-fingers .gist .pl-mdr {
+     color: #cc7833;
+}
+.idle-fingers .gist .pl-cos,
+.idle-fingers .gist .pl-ml,
+.idle-fingers .gist .pl-pds,
+.idle-fingers .gist .pl-s1,
+.idle-fingers .gist .pl-sol,
+.idle-fingers .gist .pl-mb,
+.idle-fingers .gist .pl-pdb {
+     color: #a5c261;
+}
+.idle-fingers .gist .pl-e,
+.idle-fingers .gist .pl-en,
+.idle-fingers .gist .pl-entl,
+.idle-fingers .gist .pl-mo,
+.idle-fingers .gist .pl-sc,
+.idle-fingers .gist .pl-sf,
+.idle-fingers .gist .pl-smi,
+.idle-fingers .gist .pl-smp,
+.idle-fingers .gist .pl-mdh,
+.idle-fingers .gist .pl-mdi {
+     color: #ffc66d;
+}
+.idle-fingers .gist .pl-ef,
+.idle-fingers .gist .pl-enf,
+.idle-fingers .gist .pl-enm,
+.idle-fingers .gist .pl-entc,
+.idle-fingers .gist .pl-entm,
+.idle-fingers .gist .pl-eoac,
+.idle-fingers .gist .pl-eoac .pl-pde,
+.idle-fingers .gist .pl-eoi,
+.idle-fingers .gist .pl-mai .pl-sf,
+.idle-fingers .gist .pl-mm,
+.idle-fingers .gist .pl-pdv,
+.idle-fingers .gist .pl-smc,
+.idle-fingers .gist .pl-som,
+.idle-fingers .gist .pl-sr,
+.idle-fingers .gist .pl-enti {
+     color: #b83426;
+}

--- a/src/themes/monokai.css
+++ b/src/themes/monokai.css
@@ -1,0 +1,145 @@
+.monokai .gist .highlight {
+    background: #272822;
+}
+.monokai .gist .blob-num,
+.monokai .gist .blob-code-inner,
+.monokai .gist .pl-s2,
+.monokai .gist .pl-stj {
+    color: #f8f8f2;
+}
+.monokai .gist .pl-c1 {
+    color: #ae81ff;
+}
+.monokai .gist .pl-enti {
+    color: #a6e22e;
+    font-weight: 700;
+}
+.monokai .gist .pl-st {
+    color: #66d9ef;
+}
+.monokai .gist .pl-mdr {
+    color: #66d9ef;
+    font-weight: 400;
+}
+.monokai .gist .pl-ms1 {
+    background: #fd971f;
+}
+.monokai .gist .pl-c,
+.monokai .gist .pl-c span,
+.monokai .gist .pl-pdc {
+    color: #75715e;
+    font-style: italic;
+}
+.monokai .gist .pl-cce,
+.monokai .gist .pl-cn,
+.monokai .gist .pl-coc,
+.monokai .gist .pl-enc,
+.monokai .gist .pl-ens,
+.monokai .gist .pl-kos,
+.monokai .gist .pl-kou,
+.monokai .gist .pl-mh .pl-pdh,
+.monokai .gist .pl-mp,
+.monokai .gist .pl-mp1 .pl-sf,
+.monokai .gist .pl-mq,
+.monokai .gist .pl-pde,
+.monokai .gist .pl-pse,
+.monokai .gist .pl-pse .pl-s2,
+.monokai .gist .pl-mp .pl-s3,
+.monokai .gist .pl-smi,
+.monokai .gist .pl-stp,
+.monokai .gist .pl-sv,
+.monokai .gist .pl-v,
+.monokai .gist .pl-vi,
+.monokai .gist .pl-vpf,
+.monokai .gist .pl-mri,
+.monokai .gist .pl-va,
+.monokai .gist .pl-vpu {
+    color: #66d9ef;
+}
+.monokai .gist .pl-cos,
+.monokai .gist .pl-ml,
+.monokai .gist .pl-pds,
+.monokai .gist .pl-s,
+.monokai .gist .pl-s1,
+.monokai .gist .pl-sol {
+    color: #e6db74;
+}
+.monokai .gist .pl-e,
+.monokai .gist .pl-ef,
+.monokai .gist .pl-en,
+.monokai .gist .pl-enf,
+.monokai .gist .pl-enm,
+.monokai .gist .pl-entc,
+.monokai .gist .pl-entm,
+.monokai .gist .pl-eoac,
+.monokai .gist .pl-eoac .pl-pde,
+.monokai .gist .pl-eoi,
+.monokai .gist .pl-mai .pl-sf,
+.monokai .gist .pl-mm,
+.monokai .gist .pl-pdv,
+.monokai .gist .pl-som,
+.monokai .gist .pl-sr,
+.monokai .gist .pl-vo {
+    color: #a6e22e;
+}
+.monokai .gist .pl-ent,
+.monokai .gist .pl-eoa,
+.monokai .gist .pl-eoai,
+.monokai .gist .pl-eoai .pl-pde,
+.monokai .gist .pl-k,
+.monokai .gist .pl-ko,
+.monokai .gist .pl-kolp,
+.monokai .gist .pl-mc,
+.monokai .gist .pl-mr,
+.monokai .gist .pl-ms,
+.monokai .gist .pl-s3,
+.monokai .gist .pl-smc,
+.monokai .gist .pl-smp,
+.monokai .gist .pl-sok,
+.monokai .gist .pl-sra,
+.monokai .gist .pl-src,
+.monokai .gist .pl-sre {
+    color: #f92672;
+}
+.monokai .gist .pl-mb,
+.monokai .gist .pl-pdb {
+    color: #e6db74;
+    font-weight: 700;
+}
+.monokai .gist .pl-mi,
+.monokai .gist .pl-pdi {
+    color: #f92672;
+    font-style: italic;
+}
+.monokai .gist .pl-pdc1,
+.monokai .gist .pl-scp {
+    color: #ae81ff;
+}
+.monokai .gist .pl-sc,
+.monokai .gist .pl-sf,
+.monokai .gist .pl-mo,
+.monokai .gist .pl-entl {
+    color: #fd971f;
+}
+.monokai .gist .pl-mi1,
+.monokai .gist .pl-mdht {
+    color: #a6e22e;
+    background: rgba(0, 64, 0, .5);
+}
+.monokai .gist .pl-md,
+.monokai .gist .pl-mdhf {
+    color: #f92672;
+    background: rgba(64, 0, 0, .5);
+}
+.monokai .gist .pl-mdh,
+.monokai .gist .pl-mdi {
+    color: #a6e22e;
+    font-weight: 400;
+}
+.monokai .gist .pl-ib,
+.monokai .gist .pl-id,
+.monokai .gist .pl-ii,
+.monokai .gist .pl-iu {
+    background: #a6e22e;
+    color: #272822;
+}

--- a/src/themes/obsidian.css
+++ b/src/themes/obsidian.css
@@ -1,0 +1,91 @@
+.obsidian .gist .highlight {
+    background: #293134;
+}
+.obsidian .gist .blob-num,
+.obsidian .gist .blob-code-inner,
+.obsidian .gist .pl-ent,
+.obsidian .gist .pl-s1,
+.obsidian .gist .pl-s1 .pl-s2,
+.obsidian .gist .pl-smi,
+.obsidian .gist .pl-smp,
+.obsidian .gist .pl-stj,
+.obsidian .gist .pl-vo,
+.obsidian .gist .pl-vpf {
+    color: #e0e2e4;
+}
+.obsidian .gist .pl-c,
+.obsidian .gist .pl-c span {
+    color: #66747b;
+    font-style: italic;
+}
+.obsidian .gist .pl-mb {
+    color: #ec7600;
+    font-weight: 700;
+}
+.obsidian .gist .pl-mh .pl-en {
+    color: #66747b;
+    font-weight: 700;
+}
+.obsidian .gist .pl-mi {
+    color: #93c763;
+    font-style: italic;
+}
+.obsidian .gist .pl-sc {
+    color: #96989a;
+}
+.obsidian .gist .pl-st {
+    color: #da4236;
+}
+.obsidian .gist .pl-c1>.pl-c1 {
+    color: #678cb1;
+}
+.obsidian .gist .pl-c1,
+.obsidian .gist .pl-sr .pl-cce {
+    color: #ffcd22;
+}
+.obsidian .gist .pl-e,
+.obsidian .gist .pl-k,
+.obsidian .gist .pl-mdh,
+.obsidian .gist .pl-mdr,
+.obsidian .gist .pl-ml,
+.obsidian .gist .pl-mm,
+.obsidian .gist .pl-mo,
+.obsidian .gist .pl-mp,
+.obsidian .gist .pl-mr,
+.obsidian .gist .pl-ms,
+.obsidian .gist .pl-s1 .pl-v,
+.obsidian .gist .pl-s3 {
+    color: #93c763;
+}
+.obsidian .gist .pl-en,
+.obsidian .gist .pl-v {
+    color: #678cb1;
+}
+.obsidian .gist .pl-mh,
+.obsidian .gist .pl-mq {
+    color: #66747b;
+}
+.obsidian .gist .pl-pds,
+.obsidian .gist .pl-s,
+.obsidian .gist .pl-s1 .pl-pse .pl-s2,
+.obsidian .gist .pl-sv {
+    color: #ec7600;
+}
+.obsidian .gist .pl-sr,
+.obsidian .gist .pl-sr .pl-sra,
+.obsidian .gist .pl-sr .pl-sre,
+.obsidian .gist .pl-src {
+    color: #d39745;
+}
+.obsidian .gist .pl-mi1,
+.obsidian .gist .pl-mdht {
+    color: #e0e2e4;
+    background: rgba(0, 64, 0, .5);
+}
+.obsidian .gist .pl-md,
+.obsidian .gist .pl-mdhf,
+.obsidian .gist .pl-id,
+.obsidian .gist .pl-ii {
+    color: #e0e2e4;
+    background: rgba(64, 0, 0, .5);
+}

--- a/src/themes/one-dark.css
+++ b/src/themes/one-dark.css
@@ -1,0 +1,154 @@
+.one-dark .gist .highlight {
+    background: #141414;
+}
+.one-dark .gist .blob-num,
+.one-dark .gist .blob-code-inner,
+.one-dark .gist .highlight,
+.one-dark .gist .pl-enm,
+.one-dark .gist .pl-ko,
+.one-dark .gist .pl-mo,
+.one-dark .gist .pl-mp1 .pl-sf,
+.one-dark .gist .pl-ms,
+.one-dark .gist .pl-pdc1,
+.one-dark .gist .pl-scp,
+.one-dark .gist .pl-smc,
+.one-dark .gist .pl-som,
+.one-dark .gist .pl-va,
+.one-dark .gist .pl-vpf,
+.one-dark .gist .pl-vpu,
+.one-dark .gist .pl-mdr {
+     color: #aab1bf;
+}
+.one-dark .gist .pl-mb,
+.one-dark .gist .pl-pdb {
+     font-weight: 700;
+}
+.one-dark .gist .pl-c,
+.one-dark .gist .pl-c span,
+.one-dark .gist .pl-pdc {
+     color: #5b6270;
+     font-style: italic;
+}
+.one-dark .gist .pl-sr .pl-cce {
+     color: #56b5c2;
+     font-weight: 400;
+}
+.one-dark .gist .pl-ef,
+.one-dark .gist .pl-en,
+.one-dark .gist .pl-enf,
+.one-dark .gist .pl-eoai,
+.one-dark .gist .pl-kos,
+.one-dark .gist .pl-mh .pl-pdh,
+.one-dark .gist .pl-mr {
+     color: #61afef;
+}
+.one-dark .gist .pl-ens,
+.one-dark .gist .pl-vi {
+     color: #be5046;
+}
+.one-dark .gist .pl-enti,
+.one-dark .gist .pl-mai .pl-sf,
+.one-dark .gist .pl-ml,
+.one-dark .gist .pl-sf,
+.one-dark .gist .pl-sr,
+.one-dark .gist .pl-sr .pl-sra,
+.one-dark .gist .pl-src,
+.one-dark .gist .pl-st,
+.one-dark .gist .pl-vo {
+     color: #56b5c2;
+}
+.one-dark .gist .pl-eoi,
+.one-dark .gist .pl-mri,
+.one-dark .gist .pl-pds,
+.one-dark .gist .pl-pse .pl-s1,
+.one-dark .gist .pl-s,
+.one-dark .gist .pl-s1 {
+     color: #97c279;
+}
+.one-dark .gist .pl-k,
+.one-dark .gist .pl-kolp,
+.one-dark .gist .pl-mc,
+.one-dark .gist .pl-pde {
+     color: #c578dd;
+}
+.one-dark .gist .pl-mi,
+.one-dark .gist .pl-pdi {
+     color: #c578dd;
+     font-style: italic;
+}
+.one-dark .gist .pl-mp,
+.one-dark .gist .pl-stp {
+     color: #818896;
+}
+.one-dark .gist .pl-mdh,
+.one-dark .gist .pl-mdi,
+.one-dark .gist .pl-mdr {
+     font-weight: 400;
+}
+.one-dark .gist .pl-mdht,
+.one-dark .gist .pl-mi1 {
+     color: #97c279;
+     background: #020;
+}
+.one-dark .gist .pl-md,
+.one-dark .gist .pl-mdhf {
+     color: #df6b75;
+     background: #200;
+}
+.one-dark .gist .pl-corl {
+     color: #df6b75;
+     text-decoration: underline;
+}
+.one-dark .gist .pl-ib {
+     background: #df6b75;
+}
+.one-dark .gist .pl-ii {
+     background: #e0c184;
+     color: #fff;
+}
+.one-dark .gist .pl-iu {
+     background: #e05151;
+}
+.one-dark .gist .pl-ms1 {
+     color: #aab1bf;
+     background: #373b41;
+}
+.one-dark .gist .pl-c1,
+.one-dark .gist .pl-cn,
+.one-dark .gist .pl-e,
+.one-dark .gist .pl-eoa,
+.one-dark .gist .pl-eoac,
+.one-dark .gist .pl-eoac .pl-pde,
+.one-dark .gist .pl-kou,
+.one-dark .gist .pl-mm,
+.one-dark .gist .pl-mp .pl-s3,
+.one-dark .gist .pl-mq,
+.one-dark .gist .pl-s3,
+.one-dark .gist .pl-sok,
+.one-dark .gist .pl-sv,
+.one-dark .gist .pl-mb {
+     color: #d19965;
+}
+.one-dark .gist .pl-enc,
+.one-dark .gist .pl-entc,
+.one-dark .gist .pl-pse .pl-s2,
+.one-dark .gist .pl-s2,
+.one-dark .gist .pl-sc,
+.one-dark .gist .pl-smp,
+.one-dark .gist .pl-sr .pl-sre,
+.one-dark .gist .pl-stj,
+.one-dark .gist .pl-v,
+.one-dark .gist .pl-pdb {
+     color: #e4bf7a;
+}
+.one-dark .gist .pl-ent,
+.one-dark .gist .pl-entl,
+.one-dark .gist .pl-entm,
+.one-dark .gist .pl-mh,
+.one-dark .gist .pl-pdv,
+.one-dark .gist .pl-smi,
+.one-dark .gist .pl-sol,
+.one-dark .gist .pl-mdh,
+.one-dark .gist .pl-mdi {
+     color: #df6b75;
+}

--- a/src/themes/pastel-on-dark.css
+++ b/src/themes/pastel-on-dark.css
@@ -1,0 +1,160 @@
+.pastel-on-dark .gist .highlight {
+    background: #2c2828;
+}
+.pastel-on-dark .gist .blob-num,
+.pastel-on-dark .gist .blob-code-inner,
+.pastel-on-dark .gist .pl-e,
+.pastel-on-dark .gist .pl-eoa,
+.pastel-on-dark .gist .pl-eoai,
+.pastel-on-dark .gist .pl-eoai .pl-pde,
+.pastel-on-dark .gist .pl-ko,
+.pastel-on-dark .gist .pl-kolp,
+.pastel-on-dark .gist .pl-mc,
+.pastel-on-dark .gist .pl-mr,
+.pastel-on-dark .gist .pl-ms,
+.pastel-on-dark .gist .pl-s3,
+.pastel-on-dark .gist .pl-sok {
+    color: #e6e1dc;
+}
+.pastel-on-dark .gist .pl-cce {
+    color: #afa472;
+}
+.pastel-on-dark .gist .pl-cn {
+    color: #ccc;
+}
+.pastel-on-dark .gist .pl-enti {
+    color: #aeb2f8;
+    font-weight: 700;
+}
+.pastel-on-dark .gist .pl-sra {
+    color: #797878;
+}
+.pastel-on-dark .gist .pl-mdr {
+    color: #757ad8;
+    font-weight: 400;
+}
+.pastel-on-dark .gist .pl-ms1 {
+    background: #bebf55;
+}
+.pastel-on-dark .gist .pl-c,
+.pastel-on-dark .gist .pl-c span,
+.pastel-on-dark .gist .pl-pdc {
+    color: #a6c6ff;
+    font-style: italic;
+}
+.pastel-on-dark .gist .pl-c1,
+.pastel-on-dark .gist .pl-st,
+.pastel-on-dark .gist .pl-vo {
+    color: #a5c261;
+}
+.pastel-on-dark .gist .pl-coc,
+.pastel-on-dark .gist .pl-en,
+.pastel-on-dark .gist .pl-enc,
+.pastel-on-dark .gist .pl-ens,
+.pastel-on-dark .gist .pl-k,
+.pastel-on-dark .gist .pl-kos,
+.pastel-on-dark .gist .pl-kou,
+.pastel-on-dark .gist .pl-mh .pl-pdh,
+.pastel-on-dark .gist .pl-mp,
+.pastel-on-dark .gist .pl-mp1 .pl-sf,
+.pastel-on-dark .gist .pl-mq,
+.pastel-on-dark .gist .pl-pde,
+.pastel-on-dark .gist .pl-pse,
+.pastel-on-dark .gist .pl-pse .pl-s2,
+.pastel-on-dark .gist .pl-s,
+.pastel-on-dark .gist .pl-mp .pl-s3,
+.pastel-on-dark .gist .pl-sc,
+.pastel-on-dark .gist .pl-stp,
+.pastel-on-dark .gist .pl-sv,
+.pastel-on-dark .gist .pl-v,
+.pastel-on-dark .gist .pl-vi,
+.pastel-on-dark .gist .pl-vpf,
+.pastel-on-dark .gist .pl-mri,
+.pastel-on-dark .gist .pl-va,
+.pastel-on-dark .gist .pl-vpu,
+.pastel-on-dark .gist .highlight-text-tex .pl-s3 {
+    color: #757ad8;
+}
+.pastel-on-dark .gist .pl-cos,
+.pastel-on-dark .gist .pl-ml,
+.pastel-on-dark .gist .pl-sol {
+    color: #66a968;
+}
+.pastel-on-dark .gist .pl-ef,
+.pastel-on-dark .gist .pl-enf,
+.pastel-on-dark .gist .pl-enm,
+.pastel-on-dark .gist .pl-entc,
+.pastel-on-dark .gist .pl-entm,
+.pastel-on-dark .gist .pl-eoac,
+.pastel-on-dark .gist .pl-eoac .pl-pde,
+.pastel-on-dark .gist .pl-eoi,
+.pastel-on-dark .gist .pl-mai .pl-sf,
+.pastel-on-dark .gist .pl-mm,
+.pastel-on-dark .gist .pl-pdv,
+.pastel-on-dark .gist .pl-smc,
+.pastel-on-dark .gist .pl-som,
+.pastel-on-dark .gist .pl-sr {
+    color: #aeb2f8;
+}
+.pastel-on-dark .gist .pl-ent,
+.pastel-on-dark .gist .highlight-text-html-basic .pl-e {
+    color: #6782d3;
+}
+.pastel-on-dark .gist .pl-mb,
+.pastel-on-dark .gist .pl-pdb {
+    color: #66a968;
+    font-weight: 700;
+}
+.pastel-on-dark .gist .pl-mi,
+.pastel-on-dark .gist .pl-pdi {
+    color: #e6e1dc;
+    font-style: italic;
+}
+.pastel-on-dark .gist .pl-pdc1,
+.pastel-on-dark .gist .pl-scp {
+    color: #4fb7c5;
+}
+.pastel-on-dark .gist .pl-pds,
+.pastel-on-dark .gist .pl-s1,
+.pastel-on-dark .gist .highlight-source-css .pl-v {
+    color: #ad9361;
+}
+.pastel-on-dark .gist .pl-s2,
+.pastel-on-dark .gist .pl-stj {
+    color: #8f938f;
+}
+.pastel-on-dark .gist .pl-sf,
+.pastel-on-dark .gist .pl-smi,
+.pastel-on-dark .gist .pl-smp,
+.pastel-on-dark .gist .pl-mo,
+.pastel-on-dark .gist .pl-entl {
+    color: #bebf55;
+}
+.pastel-on-dark .gist .pl-src,
+.pastel-on-dark .gist .pl-sre {
+    color: #e9c062;
+}
+.pastel-on-dark .gist .pl-mi1,
+.pastel-on-dark .gist .pl-mdht {
+    color: #66a968;
+    background: rgba(0, 64, 0, .5);
+}
+.pastel-on-dark .gist .pl-md,
+.pastel-on-dark .gist .pl-mdhf {
+    color: #aeb2f8;
+    background: rgba(64, 0, 0, .5);
+}
+.pastel-on-dark .gist .pl-mdh,
+.pastel-on-dark .gist .pl-mdi {
+    color: #bebf55;
+    font-weight: 400;
+}
+.pastel-on-dark .gist .pl-ib,
+.pastel-on-dark .gist .pl-iu {
+    background: #aeb2f8;
+}
+.pastel-on-dark .gist .pl-id,
+.pastel-on-dark .gist .pl-ii {
+    background: #aeb2f8;
+    color: #fff;
+}

--- a/src/themes/solarized-dark.css
+++ b/src/themes/solarized-dark.css
@@ -1,0 +1,88 @@
+.solarized-dark .gist .highlight {
+    background: #002b36;
+}
+.solarized-dark .gist .blob-num,
+.solarized-dark .gist .blob-code-inner,
+.solarized-dark .gist .pl-s1 .pl-s2,
+.solarized-dark .gist .pl-smi,
+.solarized-dark .gist .pl-smp,
+.solarized-dark .gist .pl-stj,
+.solarized-dark .gist .pl-vo,
+.solarized-dark .gist .pl-vpf {
+    color: #839496;
+}
+.solarized-dark .gist .pl-c,
+.solarized-dark .gist .pl-c span {
+    color: #586e75;
+    font-style: italic;
+}
+.solarized-dark .gist .pl-mb {
+    color: #2aa198;
+    font-weight: 700;
+}
+.solarized-dark .gist .pl-mh .pl-en {
+    color: #cb4b16;
+    font-weight: 700;
+}
+.solarized-dark .gist .pl-mi {
+    color: #859900;
+    font-style: italic;
+}
+.solarized-dark .gist .pl-c1,
+.solarized-dark .gist .pl-pds,
+.solarized-dark .gist .pl-s1,
+.solarized-dark .gist .pl-s1 .pl-pse .pl-s2,
+.solarized-dark .gist .pl-sv {
+    color: #2aa198;
+}
+.solarized-dark .gist .pl-e,
+.solarized-dark .gist .pl-en,
+.solarized-dark .gist .pl-ent,
+.solarized-dark .gist .pl-s,
+.solarized-dark .gist .pl-v {
+    color: #268bd2;
+}
+.solarized-dark .gist .pl-k,
+.solarized-dark .gist .pl-mdh,
+.solarized-dark .gist .pl-mdr,
+.solarized-dark .gist .pl-ml,
+.solarized-dark .gist .pl-mm,
+.solarized-dark .gist .pl-mo,
+.solarized-dark .gist .pl-mp,
+.solarized-dark .gist .pl-mr,
+.solarized-dark .gist .pl-ms,
+.solarized-dark .gist .pl-s1 .pl-v,
+.solarized-dark .gist .pl-s3 {
+    color: #859900;
+}
+.solarized-dark .gist .pl-mh,
+.solarized-dark .gist .pl-sc,
+.solarized-dark .gist .pl-sr .pl-cce {
+    color: #cb4b16;
+}
+.solarized-dark .gist .pl-mq,
+.solarized-dark .gist .highlight-source-css .pl-k {
+    color: #586e75;
+}
+.solarized-dark .gist .pl-sr,
+.solarized-dark .gist .pl-sr .pl-sra,
+.solarized-dark .gist .pl-sr .pl-sre,
+.solarized-dark .gist .pl-src {
+    color: #d30102;
+}
+.solarized-dark .gist .pl-st,
+.solarized-dark .gist .highlight-source-c\+\+ .pl-s {
+    color: #dc322f;
+}
+.solarized-dark .gist .pl-mi1,
+.solarized-dark .gist .pl-mdht {
+    color: #839496;
+    background: rgba(0, 64, 0, .5);
+}
+.solarized-dark .gist .pl-md,
+.solarized-dark .gist .pl-mdhf,
+.solarized-dark .gist .pl-id,
+.solarized-dark .gist .pl-ii {
+    color: #839496;
+    background: rgba(64, 0, 0, .5);
+}

--- a/src/themes/solarized-light.css
+++ b/src/themes/solarized-light.css
@@ -1,0 +1,88 @@
+.solarized-light .gist .highlight {
+    background: #fdf6e3;
+}
+.solarized-light .gist .blob-num,
+.solarized-light .gist .blob-code-inner,
+.solarized-light .gist .pl-s1 .pl-s2,
+.solarized-light .gist .pl-smi,
+.solarized-light .gist .pl-smp,
+.solarized-light .gist .pl-stj,
+.solarized-light .gist .pl-vo,
+.solarized-light .gist .pl-vpf {
+    color: #657b83;
+}
+.solarized-light .gist .pl-c,
+.solarized-light .gist .pl-c span {
+    color: #93a1a1;
+    font-style: italic;
+}
+.solarized-light .gist .pl-mb {
+    color: #2aa198;
+    font-weight: 700;
+}
+.solarized-light .gist .pl-mh .pl-en {
+    color: #cb4b16;
+    font-weight: 700;
+}
+.solarized-light .gist .pl-mi {
+    color: #859900;
+    font-style: italic;
+}
+.solarized-light .gist .pl-c1,
+.solarized-light .gist .pl-pds,
+.solarized-light .gist .pl-s1,
+.solarized-light .gist .pl-s1 .pl-pse .pl-s2,
+.solarized-light .gist .pl-sv {
+    color: #2aa198;
+}
+.solarized-light .gist .pl-e,
+.solarized-light .gist .pl-en,
+.solarized-light .gist .pl-ent,
+.solarized-light .gist .pl-s,
+.solarized-light .gist .pl-v {
+    color: #268bd2;
+}
+.solarized-light .gist .pl-k,
+.solarized-light .gist .pl-mdh,
+.solarized-light .gist .pl-mdr,
+.solarized-light .gist .pl-ml,
+.solarized-light .gist .pl-mm,
+.solarized-light .gist .pl-mo,
+.solarized-light .gist .pl-mp,
+.solarized-light .gist .pl-mr,
+.solarized-light .gist .pl-ms,
+.solarized-light .gist .pl-s1 .pl-v,
+.solarized-light .gist .pl-s3 {
+    color: #859900;
+}
+.solarized-light .gist .pl-mh,
+.solarized-light .gist .pl-sc,
+.solarized-light .gist .pl-sr .pl-cce {
+    color: #cb4b16;
+}
+.solarized-light .gist .pl-mq,
+.solarized-light .gist .highlight-source-css .pl-k {
+    color: #93a1a1;
+}
+.solarized-light .gist .pl-sr,
+.solarized-light .gist .pl-sr .pl-sra,
+.solarized-light .gist .pl-sr .pl-sre,
+.solarized-light .gist .pl-src {
+    color: #d30102;
+}
+.solarized-light .gist .pl-st,
+.solarized-light .gist .highlight-source-c\+\+ .pl-s {
+    color: #dc322f;
+}
+.solarized-light .gist .pl-mi1,
+.solarized-light .gist .pl-mdht {
+    color: #657b83;
+    background: rgba(0, 64, 0, .5);
+}
+.solarized-light .gist .pl-md,
+.solarized-light .gist .pl-mdhf,
+.solarized-light .gist .pl-id,
+.solarized-light .gist .pl-ii {
+    color: #657b83;
+    background: rgba(64, 0, 0, .5);
+}

--- a/src/themes/terminal.css
+++ b/src/themes/terminal.css
@@ -1,0 +1,103 @@
+.terminal .gist .highlight {
+    background: #000;
+}
+.terminal .gist .blob-num,
+.terminal .gist .blob-code-inner,
+.terminal .gist .pl-en,
+.terminal .gist .pl-sc,
+.terminal .gist .highlight-source-css .pl-k,
+.terminal .gist .highlight-source-css .pl-ent {
+    color: #dedede;
+}
+.terminal .gist .pl-c,
+.terminal .gist .pl-c span {
+    color: #ff4500;
+    font-style: italic;
+}
+.terminal .gist .pl-mb {
+    color: #e78c45;
+    font-weight: 700;
+}
+.terminal .gist .pl-mh .pl-en {
+    color: #b9ca4a;
+    font-weight: 700;
+}
+.terminal .gist .pl-mi {
+    color: #ff6347;
+    font-style: italic;
+}
+.terminal .gist .pl-mq {
+    color: #ff4500;
+}
+.terminal .gist .pl-id {
+    color: #ced2cf;
+    background: #b798bf;
+}
+.terminal .gist .pl-ii {
+    color: #ff0;
+    background: red;
+}
+.terminal .gist .highlight-source-js .pl-k {
+    color: #ff1493;
+}
+.terminal .gist .pl-c1,
+.terminal .gist .pl-s1 .pl-pse .pl-s2,
+.terminal .gist .pl-sv,
+.terminal .gist .pl-vpf {
+    color: #e78c45;
+}
+.terminal .gist .pl-e,
+.terminal .gist .pl-s3,
+.terminal .gist .pl-sr,
+.terminal .gist .pl-sr .pl-sra,
+.terminal .gist .pl-sr .pl-sre,
+.terminal .gist .pl-src,
+.terminal .gist .pl-v,
+.terminal .gist .highlight-text-html-basic .pl-ent,
+.terminal .gist .highlight-text-html-php .pl-vo {
+    color: #d54e53;
+}
+.terminal .gist .pl-ent,
+.terminal .gist .pl-k,
+.terminal .gist .pl-mdh,
+.terminal .gist .pl-mdr,
+.terminal .gist .pl-ml,
+.terminal .gist .pl-mm,
+.terminal .gist .pl-mo,
+.terminal .gist .pl-mp,
+.terminal .gist .pl-mr,
+.terminal .gist .pl-ms,
+.terminal .gist .pl-s,
+.terminal .gist .pl-s1 .pl-v,
+.terminal .gist .pl-st {
+    color: #ff6347;
+}
+.terminal .gist .pl-mh,
+.terminal .gist .pl-pds,
+.terminal .gist .pl-s1,
+.terminal .gist .pl-sr .pl-cce {
+    color: #b9ca4a;
+}
+.terminal .gist .pl-s1 .pl-s2,
+.terminal .gist .pl-smi,
+.terminal .gist .pl-smp,
+.terminal .gist .pl-stj,
+.terminal .gist .pl-vo,
+.terminal .gist .highlight-text-html-php .pl-s3,
+.terminal .gist .highlight-source-python .pl-s3 {
+    color: #7aa6da;
+}
+.terminal .gist .pl-mi1,
+.terminal .gist .pl-mdht {
+    color: #dedede;
+    background: rgba(0, 64, 0, .5);
+}
+.terminal .gist .pl-md,
+.terminal .gist .pl-mdhf {
+    color: #dedede;
+    background: red;
+}
+.terminal .gist .highlight-source-css .pl-s3,
+.terminal .gist .highlight-source-css .pl-sc {
+    color: #e7c547;
+}

--- a/src/themes/tomorrow-night.css
+++ b/src/themes/tomorrow-night.css
@@ -1,0 +1,149 @@
+.tomorrow-night .gist .highlight {
+    background: #1d1f21;
+}
+.tomorrow-night .gist .blob-num,
+.tomorrow-night .gist .blob-code-inner {
+    color: #c5c8c6;
+}
+.tomorrow-night .gist .pl-enti {
+    color: #f0c674;
+    font-weight: 700;
+}
+.tomorrow-night .gist .pl-s3 {
+    color: #81a2be;
+}
+.tomorrow-night .gist .pl-sf {
+    color: #dad085;
+}
+.tomorrow-night .gist .pl-mdr {
+    color: #de935f;
+    font-weight: 400;
+}
+.tomorrow-night .gist .pl-ms1 {
+    background: #c5c8c6;
+}
+.tomorrow-night .gist .pl-c,
+.tomorrow-night .gist .pl-c span,
+.tomorrow-night .gist .pl-pdc {
+    color: #969896;
+    font-style: italic;
+}
+.tomorrow-night .gist .pl-c1,
+.tomorrow-night .gist .pl-cce,
+.tomorrow-night .gist .pl-cn,
+.tomorrow-night .gist .pl-coc,
+.tomorrow-night .gist .pl-enc,
+.tomorrow-night .gist .pl-ens,
+.tomorrow-night .gist .pl-kos,
+.tomorrow-night .gist .pl-kou,
+.tomorrow-night .gist .pl-mh .pl-pdh,
+.tomorrow-night .gist .pl-mq,
+.tomorrow-night .gist .pl-pdc1,
+.tomorrow-night .gist .pl-pde,
+.tomorrow-night .gist .pl-pse,
+.tomorrow-night .gist .pl-pse .pl-s2,
+.tomorrow-night .gist .pl-scp,
+.tomorrow-night .gist .pl-stp,
+.tomorrow-night .gist .pl-sv,
+.tomorrow-night .gist .pl-v,
+.tomorrow-night .gist .pl-vi,
+.tomorrow-night .gist .pl-vpf,
+.tomorrow-night .gist .pl-mri,
+.tomorrow-night .gist .pl-va,
+.tomorrow-night .gist .pl-vpu {
+    color: #de935f;
+}
+.tomorrow-night .gist .pl-cos,
+.tomorrow-night .gist .pl-ml,
+.tomorrow-night .gist .pl-pds,
+.tomorrow-night .gist .pl-s1,
+.tomorrow-night .gist .pl-sol {
+    color: #b5bd68;
+}
+.tomorrow-night .gist .pl-e,
+.tomorrow-night .gist .pl-ef,
+.tomorrow-night .gist .pl-en,
+.tomorrow-night .gist .pl-enf,
+.tomorrow-night .gist .pl-enm,
+.tomorrow-night .gist .pl-entc,
+.tomorrow-night .gist .pl-eoi,
+.tomorrow-night .gist .pl-smc {
+    color: #f0c674;
+}
+.tomorrow-night .gist .pl-ent,
+.tomorrow-night .gist .pl-eoa,
+.tomorrow-night .gist .pl-eoai,
+.tomorrow-night .gist .pl-eoai .pl-pde,
+.tomorrow-night .gist .pl-k,
+.tomorrow-night .gist .pl-ko,
+.tomorrow-night .gist .pl-kolp,
+.tomorrow-night .gist .pl-mc,
+.tomorrow-night .gist .pl-mr,
+.tomorrow-night .gist .pl-ms,
+.tomorrow-night .gist .pl-s,
+.tomorrow-night .gist .pl-mp .pl-s3,
+.tomorrow-night .gist .pl-sok,
+.tomorrow-night .gist .pl-sra,
+.tomorrow-night .gist .pl-src,
+.tomorrow-night .gist .pl-sre,
+.tomorrow-night .gist .pl-st {
+    color: #b294bb;
+}
+.tomorrow-night .gist .pl-entm,
+.tomorrow-night .gist .pl-eoac,
+.tomorrow-night .gist .pl-eoac .pl-pde,
+.tomorrow-night .gist .pl-mai .pl-sf,
+.tomorrow-night .gist .pl-mm,
+.tomorrow-night .gist .pl-pdv,
+.tomorrow-night .gist .pl-som,
+.tomorrow-night .gist .pl-sr,
+.tomorrow-night .gist .pl-vo {
+    color: #c66;
+}
+.tomorrow-night .gist .pl-mb,
+.tomorrow-night .gist .pl-pdb {
+    color: #b5bd68;
+    font-weight: 700;
+}
+.tomorrow-night .gist .pl-mi,
+.tomorrow-night .gist .pl-pdi {
+    color: #b294bb;
+    font-style: italic;
+}
+.tomorrow-night .gist .pl-mp,
+.tomorrow-night .gist .pl-mp1 .pl-sf {
+    color: #81a2be;
+}
+.tomorrow-night .gist .pl-s2,
+.tomorrow-night .gist .pl-sc,
+.tomorrow-night .gist .pl-smi,
+.tomorrow-night .gist .pl-smp,
+.tomorrow-night .gist .pl-stj,
+.tomorrow-night .gist .pl-mo,
+.tomorrow-night .gist .pl-entl {
+    color: #c5c8c6;
+}
+.tomorrow-night .gist .pl-mi1,
+.tomorrow-night .gist .pl-mdht {
+    color: #8f9d6a;
+    background: rgba(0, 64, 0, .5);
+}
+.tomorrow-night .gist .pl-md,
+.tomorrow-night .gist .pl-mdhf {
+    color: #c66;
+    background: rgba(64, 0, 0, .5);
+}
+.tomorrow-night .gist .pl-mdh,
+.tomorrow-night .gist .pl-mdi {
+    color: #c66;
+    font-weight: 400;
+}
+.tomorrow-night .gist .pl-ib,
+.tomorrow-night .gist .pl-iu {
+    background: #c66;
+}
+.tomorrow-night .gist .pl-id,
+.tomorrow-night .gist .pl-ii {
+    background: #c66;
+    color: #fff;
+}

--- a/src/themes/twilight.css
+++ b/src/themes/twilight.css
@@ -1,0 +1,159 @@
+.twilight .gist .highlight {
+    background: #141414;
+}
+.twilight .gist .blob-num,
+.twilight .gist .blob-code-inner,
+.twilight .gist .pl-s2,
+.twilight .gist .pl-smi,
+.twilight .gist .pl-smp,
+.twilight .gist .pl-entl {
+    color: #ccc;
+}
+.twilight .gist .pl-enti {
+    color: #ac885b;
+    font-weight: 700;
+}
+.twilight .gist .pl-mp {
+    color: #c5af75;
+}
+.twilight .gist .pl-s {
+    color: #f9ee98;
+}
+.twilight .gist .pl-ib {
+    background: #f93;
+}
+.twilight .gist .pl-id {
+    background: #a31515;
+    color: #fff;
+}
+.twilight .gist .pl-ii {
+    background: #df5000;
+    color: #fff;
+}
+.twilight .gist .pl-iu {
+    background: #b4b7b4;
+}
+.twilight .gist .pl-mo {
+    color: #969896;
+}
+.twilight .gist .pl-ms1 {
+    background: #f5f5f5;
+}
+.twilight .gist .pl-c,
+.twilight .gist .pl-c span,
+.twilight .gist .pl-pdc {
+    color: #5f5a60;
+    font-style: italic;
+}
+.twilight .gist .pl-c1,
+.twilight .gist .pl-cn,
+.twilight .gist .pl-coc,
+.twilight .gist .pl-enc,
+.twilight .gist .pl-ens,
+.twilight .gist .pl-kos,
+.twilight .gist .pl-kou,
+.twilight .gist .pl-mh .pl-pdh,
+.twilight .gist .pl-mq,
+.twilight .gist .pl-pdc1,
+.twilight .gist .pl-pde,
+.twilight .gist .pl-pse,
+.twilight .gist .pl-pse .pl-s2,
+.twilight .gist .pl-scp,
+.twilight .gist .pl-vi {
+    color: #cf6a4c;
+}
+.twilight .gist .pl-cce,
+.twilight .gist .pl-mh,
+.twilight .gist .pl-mdr {
+    color: #cf6a4c;
+    font-weight: 400;
+}
+.twilight .gist .pl-cos,
+.twilight .gist .pl-ml,
+.twilight .gist .pl-pds,
+.twilight .gist .pl-s1,
+.twilight .gist .pl-sol {
+    color: #8f9d6a;
+}
+.twilight .gist .pl-e,
+.twilight .gist .pl-ef,
+.twilight .gist .pl-en,
+.twilight .gist .pl-enf,
+.twilight .gist .pl-enm,
+.twilight .gist .pl-entc,
+.twilight .gist .pl-eoi,
+.twilight .gist .pl-smc,
+.twilight .gist .pl-vo {
+    color: #ac885b;
+}
+.twilight .gist .pl-ent,
+.twilight .gist .pl-eoa,
+.twilight .gist .pl-eoai,
+.twilight .gist .pl-eoai .pl-pde,
+.twilight .gist .pl-k,
+.twilight .gist .pl-ko,
+.twilight .gist .pl-kolp,
+.twilight .gist .pl-mc,
+.twilight .gist .pl-mr,
+.twilight .gist .pl-ms,
+.twilight .gist .pl-mp .pl-s3,
+.twilight .gist .pl-sok,
+.twilight .gist .pl-sra,
+.twilight .gist .pl-src,
+.twilight .gist .pl-sre,
+.twilight .gist .pl-st {
+    color: #cda869;
+}
+.twilight .gist .pl-entm,
+.twilight .gist .pl-eoac,
+.twilight .gist .pl-eoac .pl-pde,
+.twilight .gist .pl-mai .pl-sf,
+.twilight .gist .pl-mm,
+.twilight .gist .pl-pdv,
+.twilight .gist .pl-som,
+.twilight .gist .pl-sr,
+.twilight .gist .pl-stj,
+.twilight .gist .pl-vpf {
+    color: #7587a6;
+}
+.twilight .gist .pl-mb,
+.twilight .gist .pl-pdb {
+    color: #8f9d6a;
+    font-weight: 700;
+}
+.twilight .gist .pl-mi,
+.twilight .gist .pl-pdi {
+    color: #cda869;
+    font-style: italic;
+}
+.twilight .gist .pl-mp1 .pl-sf,
+.twilight .gist .pl-s3,
+.twilight .gist .pl-sc,
+.twilight .gist .pl-sf {
+    color: #dad085;
+}
+.twilight .gist .pl-stp,
+.twilight .gist .pl-sv,
+.twilight .gist .pl-v {
+    color: #9b859d;
+}
+.twilight .gist .pl-mi1,
+.twilight .gist .pl-mdht {
+    color: #55a532;
+    background: #020;
+}
+.twilight .gist .pl-md,
+.twilight .gist .pl-mdhf {
+    color: #bd2c00;
+    background: #200;
+}
+.twilight .gist .pl-mdh,
+.twilight .gist .pl-mdi {
+    color: #7587a6;
+    font-weight: 400;
+}
+.twilight .gist .pl-mri,
+.twilight .gist .pl-va,
+.twilight .gist .pl-vpu {
+    color: teal;
+}


### PR DESCRIPTION
This PR adds the basic functionalities expected from this component.

With this, you can:
- Link this npm project within your project
- Passing an id (and file) of a gist, render the gist as if it was embed using <script> tag (in medium, for example).
- Chose a specific theme to render the gist. The supported theme are: chaos, cobalt, idle-fingers, monokai, obsidian, one-dark, pastel-on-dark, solarized-dark, solarized-light, terminal, tomorrow-night and twilight.

Example:
![deepinscreenshot_select-area_20181003221144](https://user-images.githubusercontent.com/9984086/46439817-6f697880-c759-11e8-984e-93e852d667dd.png)
